### PR TITLE
add attribute for secure log location

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The default is `[]`.
 
 The log file that contains sshd logging info.
 
-The default is `/var/log/auth.log`.
+The default is based on your platform.
 
 
 # USAGE

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Hostnames that will always be allowed to connect.
 
 The default is `[]`.
 
+## `secure_log`
+
+The log file that contains sshd logging info.
+
+The default is `/var/log/auth.log`.
+
 
 # USAGE
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The following platforms are supported by this cookbook, meaning that the recipes
 
 * Ubuntu
 * Debian
+* RedHat
+* CentOS
 
 
 # ATTRIBUTES

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,3 +22,4 @@ default["denyhosts"]["smtp_host"]     = "localhost"
 default["denyhosts"]["smtp_port"]     = "25"
 default["denyhosts"]["smtp_from"]     = "denyhosts@localhost"
 default["denyhosts"]["allowed_hosts"] = []
+default["denyhosts"]["secure_log"]    = "/var/log/auth.log"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,4 +22,17 @@ default["denyhosts"]["smtp_host"]     = "localhost"
 default["denyhosts"]["smtp_port"]     = "25"
 default["denyhosts"]["smtp_from"]     = "denyhosts@localhost"
 default["denyhosts"]["allowed_hosts"] = []
-default["denyhosts"]["secure_log"]    = "/var/log/auth.log"
+default["denyhosts"]["secure_log"]    = case node['platform_family']
+                                        when "rhel", "fedora"
+                                          "/var/log/secure"
+                                        when "freebsd", "openbsd"
+                                          "/var/log/auth.log"
+                                        when "suse"
+                                          "/var/log/messages"
+                                        when "mac_os_x"
+                                          "/private/var/log/asl.log"
+                                        when "debian"
+                                          "/var/log/auth.log"
+                                        else
+                                          "/var/log/auth.log"
+                                        end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ license          "Apache 2.0"
 description      "Installs denyhosts"
 version          "0.1"
 
-%w{ubuntu debian}.each do |os|
+%w{ubuntu debian redhat centos}.each do |os|
   supports os
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -32,3 +32,9 @@ attribute "denyhosts/allowed_hosts",
   :display_name => "Allowed hosts",
   :description  => "Hostnames that will always be allowed to connect",
   :default      => []
+
+attribute "denyhosts/secure_log",
+  :display_name => "Secure log location",
+  :description  => "The log file that contains sshd logging info.",
+  :type => "string",
+  :default => "/var/log/auth.log"

--- a/metadata.rb
+++ b/metadata.rb
@@ -37,4 +37,4 @@ attribute "denyhosts/secure_log",
   :display_name => "Secure log location",
   :description  => "The log file that contains sshd logging info.",
   :type => "string",
-  :default => "/var/log/auth.log"
+  :calculated => true

--- a/templates/default/denyhosts.conf.erb
+++ b/templates/default/denyhosts.conf.erb
@@ -25,7 +25,9 @@
 #SECURE_LOG=/private/var/log/system.log
 #
 # Debian:
-SECURE_LOG = /var/log/auth.log
+#SECURE_LOG = /var/log/auth.log
+
+SECURE_LOG = <%= node[:denyhosts][:secure_log] %>
 ########################################################################
 
 ########################################################################


### PR DESCRIPTION
Currently defaults to the previous value (Debian). Working on platform specific defaults now.
